### PR TITLE
Feat: bump toolchain from nightly-2023-03-09 to nightly-2025-06-27

### DIFF
--- a/section-5-detection/AtomVChecker/examples/RUSTSEC-2022-0006/rust-toolchain.toml
+++ b/section-5-detection/AtomVChecker/examples/RUSTSEC-2022-0006/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2023-03-09"
-components = [ "rust-src", "rustc-dev", "llvm-tools-preview", "clippy" ]

--- a/section-5-detection/AtomVChecker/examples/RUSTSEC-2022-0029/rust-toolchain.toml
+++ b/section-5-detection/AtomVChecker/examples/RUSTSEC-2022-0029/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2023-03-09"
-components = [ "rust-src", "rustc-dev", "llvm-tools-preview", "clippy" ]

--- a/section-5-detection/AtomVChecker/rust-toolchain.toml
+++ b/section-5-detection/AtomVChecker/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-03-09"
+channel = "nightly-2025-06-27"
 components = [ "rust-src", "rustc-dev", "llvm-tools-preview", "clippy" ]

--- a/section-5-detection/AtomVChecker/src/analysis/controldep/mod.rs
+++ b/section-5-detection/AtomVChecker/src/analysis/controldep/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 
 use crate::analysis::postdom::{post_dominators, EndsControlFlowGraph};
 use rustc_data_structures::fx::FxHashSet;
-use rustc_index::vec::{Idx, IndexVec};
+use rustc_index::{Idx, IndexVec};
 
 #[derive(Clone, Debug)]
 pub struct ControlDeps<N: Idx> {

--- a/section-5-detection/AtomVChecker/src/analysis/defuse/mod.rs
+++ b/section-5-detection/AtomVChecker/src/analysis/defuse/mod.rs
@@ -55,16 +55,10 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
         // and we only care about the result at suspension points. Borrows cannot
         // cross suspension points so this behavior is unproblematic.
         PlaceContext::MutatingUse(MutatingUseContext::Borrow) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow) |
-
-        PlaceContext::MutatingUse(MutatingUseContext::AddressOf) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::AddressOf) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) |
-        PlaceContext::NonUse(NonUseContext::AscribeUserTy) |
+        // FIXME: how to handle rest of variants
+        // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/visit/enum.NonMutatingUseContext.html
+        PlaceContext::NonMutatingUse(_) |
+        PlaceContext::NonUse(NonUseContext::AscribeUserTy(_)) |
         PlaceContext::MutatingUse(MutatingUseContext::Retag) =>
             Some(DefUse::Use),
 
@@ -85,6 +79,7 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
         PlaceContext::MutatingUse(MutatingUseContext::Deinit | MutatingUseContext::SetDiscriminant) => {
             None
         }
+        _=>None
     }
 }
 

--- a/section-5-detection/AtomVChecker/src/analysis/postdom/mod.rs
+++ b/section-5-detection/AtomVChecker/src/analysis/postdom/mod.rs
@@ -3,10 +3,8 @@ extern crate rustc_data_structures;
 extern crate rustc_index;
 extern crate rustc_middle;
 
-use rustc_data_structures::graph::{
-    ControlFlowGraph, DirectedGraph, WithNumNodes, WithPredecessors, WithSuccessors,
-};
-use rustc_index::vec::{Idx, IndexVec};
+use rustc_data_structures::graph::{ControlFlowGraph, DirectedGraph, Predecessors, Successors};
+use rustc_index::{Idx, IndexVec};
 use rustc_middle::mir::{BasicBlock, BasicBlocks, Location, TerminatorKind};
 use std::borrow::BorrowMut;
 
@@ -66,9 +64,7 @@ pub fn post_dominators<G: EndsControlFlowGraph>(graph: G) -> PostDominators<G::N
     post_dominators_given_rpo(graph, &rpo)
 }
 
-pub fn postdom_reverse_post_order<
-    G: DirectedGraph + WithPredecessors + WithNumNodes + WithEndNodes,
->(
+pub fn postdom_reverse_post_order<G: DirectedGraph + Predecessors + WithEndNodes>(
     graph: &G,
     end_nodes: Vec<G::Node>,
 ) -> Vec<G::Node> {
@@ -77,18 +73,14 @@ pub fn postdom_reverse_post_order<
     vec
 }
 
-pub fn postdom_post_order_from<
-    G: DirectedGraph + WithPredecessors + WithNumNodes + WithEndNodes,
->(
+pub fn postdom_post_order_from<G: DirectedGraph + Predecessors + WithEndNodes>(
     graph: &G,
     end_nodes: Vec<G::Node>,
 ) -> Vec<G::Node> {
     postdom_post_order_from_to(graph, end_nodes, None)
 }
 
-pub fn postdom_post_order_from_to<
-    G: DirectedGraph + WithPredecessors + WithNumNodes + WithEndNodes,
->(
+pub fn postdom_post_order_from_to<G: DirectedGraph + Predecessors + WithEndNodes>(
     graph: &G,
     end_nodes: Vec<G::Node>,
     start_node: Option<G::Node>,
@@ -106,7 +98,7 @@ pub fn postdom_post_order_from_to<
     result
 }
 
-fn postdom_post_order_walk<G: DirectedGraph + WithPredecessors + WithNumNodes>(
+fn postdom_post_order_walk<G: DirectedGraph + Predecessors>(
     graph: &G,
     node: G::Node,
     result: &mut Vec<G::Node>,

--- a/section-5-detection/AtomVChecker/src/analysis/postdom/tests.rs
+++ b/section-5-detection/AtomVChecker/src/analysis/postdom/tests.rs
@@ -1,11 +1,9 @@
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::{fx::FxHashMap, graph::depth_first_search};
 use std::cmp::max;
-use std::iter;
-use std::slice;
 
 use super::*;
 
-use rustc_data_structures::graph::{GraphPredecessors, GraphSuccessors, WithStartNode};
+use rustc_data_structures::graph::{Predecessors, StartNode, Successors};
 
 pub struct TestGraph {
     num_nodes: usize,
@@ -38,9 +36,12 @@ impl TestGraph {
 
 impl DirectedGraph for TestGraph {
     type Node = usize;
+    fn num_nodes(&self) -> usize {
+        self.num_nodes
+    }
 }
 
-impl WithStartNode for TestGraph {
+impl StartNode for TestGraph {
     fn start_node(&self) -> usize {
         self.start_node
     }
@@ -49,7 +50,7 @@ impl WithStartNode for TestGraph {
 impl WithEndNodes for TestGraph {
     fn end_nodes(&self) -> Vec<usize> {
         let mut result = vec![];
-        for node in self.depth_first_search(self.start_node()) {
+        for node in depth_first_search(self, self.start_node()) {
             if self.successors(node).count() == 0 {
                 result.push(node);
             }
@@ -59,32 +60,16 @@ impl WithEndNodes for TestGraph {
     }
 }
 
-impl WithNumNodes for TestGraph {
-    fn num_nodes(&self) -> usize {
-        self.num_nodes
-    }
-}
-
-impl WithPredecessors for TestGraph {
-    fn predecessors(&self, node: usize) -> <Self as GraphPredecessors<'_>>::Iter {
+impl Predecessors for TestGraph {
+    fn predecessors(&self, node: usize) -> impl Iterator<Item = Self::Node> {
         self.predecessors[&node].iter().cloned()
     }
 }
 
-impl WithSuccessors for TestGraph {
-    fn successors(&self, node: usize) -> <Self as GraphSuccessors<'_>>::Iter {
+impl Successors for TestGraph {
+    fn successors(&self, node: usize) -> impl Iterator<Item = Self::Node> {
         self.successors[&node].iter().cloned()
     }
-}
-
-impl<'graph> GraphPredecessors<'graph> for TestGraph {
-    type Item = usize;
-    type Iter = iter::Cloned<slice::Iter<'graph, usize>>;
-}
-
-impl<'graph> GraphSuccessors<'graph> for TestGraph {
-    type Item = usize;
-    type Iter = iter::Cloned<slice::Iter<'graph, usize>>;
 }
 
 #[test]

--- a/section-5-detection/AtomVChecker/src/detector/atomic/mod.rs
+++ b/section-5-detection/AtomVChecker/src/detector/atomic/mod.rs
@@ -20,7 +20,7 @@ extern crate rustc_middle;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
-use log::{debug, warn};
+use log::debug;
 use regex::Regex;
 use rustc_middle::mir::{Body, Local, Location, Place, PlaceRef, ProjectionElem};
 use rustc_middle::ty::TyCtxt;
@@ -448,9 +448,7 @@ impl<'tcx> AtomicityViolationDetector<'tcx> {
                 CallGraphNode::WithBody(instance) => instance,
                 CallGraphNode::WithoutBody(instance) => instance,
             };
-            let func_name = self
-                .tcx
-                .def_path_str_with_substs(inst.def_id(), inst.substs);
+            let func_name = self.tcx.def_path_str(inst.def_id());
             let re = Regex::new(r"^(std|core)::sync::atomic::((AtomicPtr)(::<(.*?)>)?|(Atomic[A-Za-z]+)(::<(.*?)>)?)(::)?(load|store|swap|compare_exchange(_weak)?|fetch_(and|add|sub|or|update|max|xor)|compare_and_swap)").unwrap();
 
             // Identify atomic operations and distinguish between AtomicPtr and non-AtomicPtr

--- a/section-5-detection/AtomVChecker/src/interest/memory/ownership.rs
+++ b/section-5-detection/AtomVChecker/src/interest/memory/ownership.rs
@@ -3,16 +3,16 @@ extern crate rustc_middle;
 
 use regex::Regex;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{SubstsRef, TyCtxt};
+use rustc_middle::ty::{GenericArg, TyCtxt};
 
 /// y = Arc::clone(x)
-pub fn is_arc_or_rc_clone<'tcx>(def_id: DefId, substs: SubstsRef<'tcx>, tcx: TyCtxt<'tcx>) -> bool {
+pub fn is_arc_or_rc_clone<'tcx>(def_id: DefId, args: &[GenericArg], tcx: TyCtxt<'tcx>) -> bool {
     let fn_name = tcx.def_path_str(def_id);
     if fn_name != "std::clone::Clone::clone" {
         return false;
     }
 
-    if let &[arg] = substs.as_ref() {
+    if let &[arg] = args {
         let arg_ty_name = format!("{:?}", arg);
         if is_arc(&arg_ty_name) || is_rc(&arg_ty_name) {
             return true;


### PR DESCRIPTION
This PR only replaces rustc internal APIs from older to the newer.

But it seems to break the ability of analysis and checking, since no diagnostics are emitted anymore.

